### PR TITLE
Moving allocators init

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -79,6 +79,9 @@ rcl_init(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     context->impl, "failed to allocate memory for context impl", return RCL_RET_BAD_ALLOC);
 
+  // Store the allocator.
+  context->impl->allocator = allocator;
+
   // Zero initialize rmw context first so its validity can by checked in cleanup.
   context->impl->rmw_context = rmw_get_zero_initialized_context();
 
@@ -146,9 +149,6 @@ rcl_init(
     fail_ret = rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
     goto fail;
   }
-
-  // Store the allocator.
-  context->impl->allocator = allocator;
 
   return RCL_RET_OK;
 fail:


### PR DESCRIPTION
This PR moves the copying of the allocators in order to be able to use them  `__cleanup_context` if `rmw_init` fails.

It is implemented on ros2/rcl repo newest version: https://github.com/ros2/rcl/blob/b714f41acabc46a645a7a98a90a6482eef672048/rcl/src/rcl/init.c#L96

Related to:

- [ ] https://github.com/micro-ROS/micro-ros-build/pull/104
- [ ] https://github.com/micro-ROS/freertos_apps/pull/2
- [ ] https://github.com/micro-ROS/rmw-microxrcedds/pull/59
- [ ] https://github.com/micro-ROS/rcl/pull/5
- [ ] https://github.com/micro-ROS/rcutils/pull/7