### PR TITLE
Avoid logging on build time based on RCutils flags

### DIFF
--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -72,9 +72,13 @@ rcl_logging_configure(const rcl_arguments_t * global_args, const rcl_allocator_t
     g_logging_allocator = *allocator;
   int default_level = global_args->impl->log_level;
   const char * config_file = global_args->impl->external_log_config_file;
-  g_rcl_logging_stdout_enabled = !global_args->impl->log_stdout_disabled;
-  g_rcl_logging_rosout_enabled = !global_args->impl->log_rosout_disabled;
-  g_rcl_logging_ext_lib_enabled = !global_args->impl->log_ext_lib_disabled;
+  bool global_disable = false;
+  #ifdef RCUTILS_NO_LOGGING
+    global_disable = true;
+  #endif
+  g_rcl_logging_stdout_enabled = !global_args->impl->log_stdout_disabled && !global_disable;
+  g_rcl_logging_rosout_enabled = !global_args->impl->log_rosout_disabled && !global_disable;
+  g_rcl_logging_ext_lib_enabled = !global_args->impl->log_ext_lib_disabled && !global_disable;
   rcl_ret_t status = RCL_RET_OK;
   g_rcl_logging_num_out_handlers = 0;
 


### PR DESCRIPTION
This PR add functionality to avoid logging based on a flag instead of taking argc and argv. This aims to avoid string operations on micro-ROS