### PR TITLE
Disable get_type_description service

### DIFF
--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -580,6 +580,7 @@ void rcl_node_type_description_service_handle_request(
   const type_description_interfaces__srv__GetTypeDescription_Request * request,
   type_description_interfaces__srv__GetTypeDescription_Response * response)
 {
+#ifdef RCL_MICROROS_COMPLETE_IMPL
   rcl_type_info_t type_info;
   RCL_CHECK_FOR_NULL_WITH_MSG(node, "invalid node handle", return;);
   RCL_CHECK_FOR_NULL_WITH_MSG(node->impl, "invalid node", return;);
@@ -638,10 +639,12 @@ void rcl_node_type_description_service_handle_request(
   }
 
   response->successful = true;
+#endif //RCL_MICROROS
 }
 
 rcl_ret_t rcl_node_type_description_service_init(rcl_node_t * node)
 {
+#ifdef RCL_MICROROS_COMPLETE_IMPL
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
 
@@ -675,12 +678,15 @@ rcl_ret_t rcl_node_type_description_service_init(rcl_node_t * node)
     &node->impl->get_type_description_service, node,
     type_support, service_name, &service_ops);
   allocator.deallocate(service_name, allocator.state);
-
   return ret;
+#else
+  return RCL_RET_OK;
+#endif //RCL_MICROROS
 }
 
 rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node)
 {
+#ifdef RCL_MICROROS_COMPLETE_IMPL
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
   if (!rcl_service_is_valid(&node->impl->get_type_description_service)) {
@@ -695,12 +701,16 @@ rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node)
   }
 
   return ret;
+#else
+  return RCL_RET_OK;
+#endif //RCL_MICROROS
 }
 
 rcl_ret_t rcl_node_get_type_description_service(
   const rcl_node_t * node,
   rcl_service_t ** service_out)
 {
+#ifdef RCL_MICROROS_COMPLETE_IMPL
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(service_out, RCL_RET_SERVICE_INVALID);
@@ -710,6 +720,7 @@ rcl_ret_t rcl_node_get_type_description_service(
   }
 
   *service_out = &node->impl->get_type_description_service;
+#endif
   return RCL_RET_OK;
 }
 


### PR DESCRIPTION
Related to https://github.com/ros2/rcl/pull/1052.

This service is implemented to check type compatibility at the node level, its safe to leave it out of micro-ROS for now.
This will need to be addressed when the type Hash is implemented on the complete micro-ROS stack.