### PR TITLE
exclude rcl_validate_enclave_name and rcl_get_security_options_from_e…

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -234,7 +234,6 @@ rcl_init(
     fail_ret = RCL_RET_BAD_ALLOC;
     goto fail;
   }
-#endif //RCL_MICROROS
 
   int validation_result;
   size_t invalid_index;
@@ -266,6 +265,7 @@ rcl_init(
     fail_ret = ret;
     goto fail;
   }
+#endif //RCL_MICROROS
 
   // Initialize rmw_init.
   rmw_ret_t rmw_ret = rmw_init(


### PR DESCRIPTION
Exclude validation to enclave name in micro-ROS since it failed after applying https://github.com/micro-ROS/rmw_microxrcedds/pull/318 to rmw.
Exclude also security options related code since it is not necessary.