### PR TITLE
Fix CMake generator expression

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -92,7 +92,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(${PROJECT_NAME} PUBLIC
   # TODO(clalancette): rcl_interfaces should be PRIVATE, but downstream depends on it for now
-  $<$<NOT:$<BOOL:${RCL_MICROROS}>>:${rcl_interfaces_TARGETS}>
+  "$<$<NOT:$<BOOL:${RCL_MICROROS}>>:${rcl_interfaces_TARGETS}>"
   # TODO(clalancette): rcl_logging_interface should be PRIVATE, but downstream depends on it for now
   $<$<NOT:$<BOOL:${RCL_MICROROS}>>:rcl_logging_interface::rcl_logging_interface>
   rcutils::rcutils


### PR DESCRIPTION
When building the kilted branch of [micro-ROS/micro_ros_espidf_component](https://github.com/micro-ROS/micro_ros_espidf_component), I get the following error:

```
--- stderr: rcl
CMake Error at CMakeLists.txt:88 (add_library):
  Target "rcl" links to target
  "$<0:rcl_interfaces::rcl_interfaces__rosidl_generator_c" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


CMake Error at CMakeLists.txt:88 (add_library):
  Target "rcl" links to target
  "rcl_interfaces::rcl_interfaces__rosidl_typesupport_c>" but the target was
  not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?


CMake Generate step failed.  Build files cannot be regenerated correctly.
```

This appears to be caused by unquoted generator expressions being split at semicolons. This issue only seems to occur with older versions of CMake. I'm using CMake 3.22.1.

Local testing confirms that the project builds successfully after the generator expressions are quoted.